### PR TITLE
[FEATURE] Show position number if position is empty

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -14,11 +14,11 @@ class Board
   def display
     puts <<~BOARD
 
-       #{@board[0]} | #{@board[1]} | #{@board[2]}
+       #{token_at(0)} | #{token_at(1)} | #{token_at(2)}
       ---+---+---
-       #{@board[3]} | #{@board[4]} | #{@board[5]}
+       #{token_at(3)} | #{token_at(4)} | #{token_at(5)}
       ---+---+---
-       #{@board[6]} | #{@board[7]} | #{@board[8]}
+       #{token_at(6)} | #{token_at(7)} | #{token_at(8)}
 
     BOARD
   end
@@ -52,5 +52,9 @@ class Board
       [0, 3, 6], [1, 4, 7], [2, 5, 8], # Columns
       [0, 4, 8], [2, 4, 6]             # Diagonals
     ]
+  end
+
+  def token_at(position)
+    @board[position] == EMPTY_CHAR ? position + 1 : @board[position]
   end
 end

--- a/spec/lib/board_spec.rb
+++ b/spec/lib/board_spec.rb
@@ -5,21 +5,41 @@ require_relative '../../lib/board'
 RSpec.describe Board do # rubocop:disable Metrics/BlockLength
   subject(:board) { described_class.new }
 
-  describe '#display' do
-    before do
-      board.instance_variable_set(:@board, %w[X O X O X O X O X])
+  describe '#display' do # rubocop:disable Metrics/BlockLength
+    context 'when the board is not full' do
+      before do
+        board.instance_variable_set(:@board, [' ', ' ', 'X', 'O', ' ', ' ', 'X', ' ', 'X'])
+      end
+
+      it 'outputs the correct board layout to stdout' do
+        expect { board.display }.to output(<<~BOARD).to_stdout
+
+           1 | 2 | X
+          ---+---+---
+           O | 5 | 6
+          ---+---+---
+           X | 8 | X
+
+        BOARD
+      end
     end
 
-    it 'outputs the correct board layout to stdout' do
-      expect { board.display }.to output(<<~BOARD).to_stdout
+    context 'when the board is full' do
+      before do
+        board.instance_variable_set(:@board, %w[X O X O X O X O X])
+      end
 
-         X | O | X
-        ---+---+---
-         O | X | O
-        ---+---+---
-         X | O | X
+      it 'outputs the correct board layout to stdout' do
+        expect { board.display }.to output(<<~BOARD).to_stdout
 
-      BOARD
+           X | O | X
+          ---+---+---
+           O | X | O
+          ---+---+---
+           X | O | X
+
+        BOARD
+      end
     end
   end
 


### PR DESCRIPTION
## Description

To help the user know the position number, the board now shows the position number for empty positions. This will make the game more accessible.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Other

## Changes

- Instead of showing the empty char por empty positions, it now shows the position number.
- It adds a new test to assert the board state for when it has empty positions.

## Checklist

- [x] My code follows the project guidelines
- [x] I have performed a self-review
- [x] My changes are tested and work as expected
